### PR TITLE
Refactor formatter

### DIFF
--- a/Scripts/crystalFormat.js
+++ b/Scripts/crystalFormat.js
@@ -1,0 +1,52 @@
+const crystalFormat = (inputText) => {
+  const setUpProcess = (reject) => {
+    const configPath = nova.workspace.config.get(
+      "com.edwardloveall.Crystal.crystalPath",
+    );
+    if (configPath.trim() === "") {
+      const message =
+        "Please provide a crystal executable in Project Settings to enable formatting.";
+      reject(message);
+    }
+    const crystalPath = nova.path.expanduser(configPath);
+
+    return new Process(crystalPath, {
+      args: ["tool", "format", "--no-color", "-"],
+      stdio: "pipe",
+    });
+  };
+
+  const writeToStdin = (process, inputText) => {
+    const writer = process.stdin.getWriter();
+    writer.ready.then(() => {
+      writer.write(inputText);
+      writer.close();
+    });
+  };
+
+  const collectOutputText = (stdout, buffer) => (buffer.stdout += stdout);
+  const collectErrorText = (stderr, buffer) => (buffer.stderr += stderr);
+
+  return new Promise((resolve, reject) => {
+    try {
+      const process = setUpProcess(reject);
+      let buffer = { stdout: "", stderr: "" };
+
+      process.onStdout((stdout) => collectOutputText(stdout, buffer));
+      process.onStderr((stderr) => collectErrorText(stderr, buffer));
+      process.onDidExit((status) => {
+        if (status === 0) {
+          resolve(buffer.stdout);
+        } else {
+          reject(buffer.stderr);
+        }
+      });
+      writeToStdin(process, inputText);
+      process.start();
+    } catch (err) {
+      reject(err);
+    }
+  });
+};
+
+module.exports = crystalFormat;


### PR DESCRIPTION
This separates the Nova API code from the code that interacts with the crystal process to format code. It turns the formatting code into a promise-based API which, if returned in Nova's [`onWillSave` method](https://docs.nova.app/api-reference/text-editor/#onwillsavecallback-thisvalue) will make sure that Nova waits until the promise resolves before saving.

This separation works well because the code to interact with the Crystal process can be blissfully unaware what happens to the output or errors. Was there some formatted code? An error? The formatting code only has to `resolve` or `reject` the promise with formatted code or an error message, respectively.

Meanwhile, the main nova code can take that code and edit the document, or an error message and display it as a notification or `console.error`.